### PR TITLE
fix(deps): use a floor pin for safetensors so fresh installs resolve

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,7 @@ pyarrow==23.0.1
 Pillow==12.1.1
 einops==0.8.2
 tqdm==4.67.3
-safetensors==0.7.0
+# diffsynth 2.0.11 does not pin transformers, and transformers >=5.13 requires
+# safetensors>=0.8.0. An exact pin here is installed last and downgrades it, breaking
+# `import diffsynth`; a floor lets pip satisfy both constraints.
+safetensors>=0.8.0


### PR DESCRIPTION
Fixes #8.

`requirements.txt` is installed after `pip install diffsynth==2.0.11`, so its exact pin `safetensors==0.7.0` downgrades the version that the diffsynth dependency chain had just resolved. `diffsynth` declares `transformers` with no upper bound, and `transformers` raised its floor to `safetensors>=0.8.0` in 5.13.0 (2026-07-03), enforced at import time. The result is that a fresh install following the README fails on `import diffsynth`:

```
ImportError: safetensors>=0.8.0 is required for a normal functioning of this module, but found safetensors==0.7.0.
```

This changes the exact pin to a floor, which lets pip satisfy both constraints and keeps working if `transformers` raises its floor again.

Safe for this codebase: safetensors 0.8.0's breaking change is limited to the low-level `serialize` / `serialize_file` API, while this repo and `diffsynth` only use the read path (`from safetensors import safe_open`).

Verified on Linux / 4xH100 / CUDA 12.8, Python 3.10.21, torch 2.8.0+cu128:

- `pip install` resolves cleanly (`safetensors-0.8.0`, `transformers-5.15.0`); `pip check` reports no broken requirements.
- `bash scripts/infer_example.sh` runs to completion on all three `demo/demo.jsonl` episodes, producing `outputs/inference/episode{0,1,2}.mp4`.
